### PR TITLE
Fix: crash if pattern is invalid

### DIFF
--- a/src/qcron.cpp
+++ b/src/qcron.cpp
@@ -22,7 +22,9 @@ QCron(const QString & pattern)
 {
     _init();
     _parsePattern(pattern);
-    _checkState();
+    if (_is_valid) {
+        _checkState();
+    }
 }
 
 /******************************************************************************/


### PR DESCRIPTION
Invalid pattern in constructor (`_parsePattern()` sets `_is_valid = false`) crashes it with _Segmentation fault_ error in function `bool QCronField::match(const QDateTime & dt) const`.
So, we have to check '_si_valid' before call `_checkState()` 