### PR TITLE
Correct crash caused by invalid cron syntax

### DIFF
--- a/src/qcron.cpp
+++ b/src/qcron.cpp
@@ -111,6 +111,10 @@ _parsePattern(const QString & pattern)
     {
         for (int i = 0; i < 6; ++i)
         {
+            if (fields[i].startsWith('/')) {
+                _setError(QStringLiteral("Invalid character at: %1").arg(i));
+                continue;
+            }
             _fields[i].parse(fields[i]);
             _is_valid &= _fields[i].isValid();
         }

--- a/src/qcron.cpp
+++ b/src/qcron.cpp
@@ -111,10 +111,6 @@ _parsePattern(const QString & pattern)
     {
         for (int i = 0; i < 6; ++i)
         {
-            if (fields[i].startsWith('/')) {
-                _setError(QStringLiteral("Invalid character at: %1").arg(i));
-                continue;
-            }
             _fields[i].parse(fields[i]);
             _is_valid &= _fields[i].isValid();
         }

--- a/src/qcronfield.cpp
+++ b/src/qcronfield.cpp
@@ -77,6 +77,10 @@ QCronField::
 _parseEvery(QString & str)
 {
     str.remove(0, 1);
+    if (!_last_node) {
+        throw QCronFieldException(QString("Every node for string %1 has null last node.")
+                                      .arg(str));
+    }
     return new QCronEveryNode(_last_node, _parseInt(str));
 }
 

--- a/test/qcron_test.cpp
+++ b/test/qcron_test.cpp
@@ -48,11 +48,6 @@ minutes()
     _tnow.setHMS(0, 0, 0);
     QCOMPARE(actual(pattern), now().addSecs(60 * 1));
 
-    // Invalid
-    pattern = "/1 * * * * *";
-    _tnow.setHMS(0, 0, 0);
-    QCOMPARE(actual(pattern), now().addSecs(60 * 1));
-
     // Int
     pattern = "30 * * * * *";
     QCOMPARE(actual(pattern), now().addSecs(60 * 30));

--- a/test/qcron_test.cpp
+++ b/test/qcron_test.cpp
@@ -22,6 +22,9 @@ QCronTest::
 actual(QString & pattern)
 {
     QCron c(pattern);
+    if (!c.isValid()) {
+        return QDateTime();
+    }
     return c.next(QDateTime(_dnow, _tnow));
 }
 
@@ -42,6 +45,11 @@ minutes()
 {
     // Star
     QString pattern = "* * * * * *";
+    _tnow.setHMS(0, 0, 0);
+    QCOMPARE(actual(pattern), now().addSecs(60 * 1));
+
+    // Invalid
+    pattern = "/1 * * * * *";
     _tnow.setHMS(0, 0, 0);
     QCOMPARE(actual(pattern), now().addSecs(60 * 1));
 

--- a/test/syntax_test.cpp
+++ b/test/syntax_test.cpp
@@ -51,7 +51,8 @@ buildTests(QStringList & good,
         buildPattern(pattern_idx, "1/2/3 * * * * *") <<
         buildPattern(pattern_idx, "1-2-3 * * * * *") << // Bad range
         buildPattern(pattern_idx, "** * * * * *") << // Bad star
-        buildPattern(pattern_idx, "1,,2 * * * * *") // Bad list
+        buildPattern(pattern_idx, "1,,2 * * * * *") << // Bad list
+        buildPattern(pattern_idx, "/1") << // invalid syntax / character
         ;
     good << buildPattern(pattern_idx, QString::number(min)) <<
          buildPattern(pattern_idx, QString("000000000%1").arg(min)) <<


### PR DESCRIPTION
Crash happens for syntax like: `/1 * * * * *` and `/1` can be on any cron field.